### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+
+v1.0.4
+- Prevent running with "sh scriptname.sh".
+
 v1.0.3
 - Added --check option to check and show currently selected RAID type.
 - Added --help option to usage options.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,3 @@
-
 v1.0.4
 - Prevent running with "sh scriptname.sh".
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 v1.0.4
+- Removed Restore menu choice as it was not needed (and was dangerous to restore synoinfo.conf from a backup in case it was made while using an older DSM version).
 - Prevent running with "sh scriptname.sh".
 
 v1.0.3

--- a/my-other-scripts.md
+++ b/my-other-scripts.md
@@ -1,0 +1,28 @@
+## All my Synology Scripts
+
+- **<a href="https://github.com/007revad/Synology_HDD_db">Synology_HDD_db</a>**
+  - Add your HDD, SSD and NVMe drives to your Synology's compatible drive database.
+
+- **<a href="https://github.com/007revad/Synology_enable_M2_volume">Synology_enable_M2_volume</a>**
+  - Enable creating volumes with non-Synology M.2 drives.
+
+- **<a href="https://github.com/007revad/Synology_M2_volume">Synology_M2_volume</a>**
+  - Easily create an M.2 volume on Synology NAS.
+
+- **<a href="https://github.com/007revad/Synology_enable_Deduplication">Synology_enable_Deduplication</a>**
+  - Enable deduplication with non-Synology SSDs and unsupported NAS models.
+
+- **<a href="https://github.com/007revad/Synology_RAID-F1_SHR_switch">Synology_RAID-F1_SHR_switch</a>**
+  - Easily switch between SHR and RAID F1.
+
+- **<a href="https://github.com/007revad/Synology_Config_Backup">Synology_Config_Backup</a>**
+  - Backup and export your Synology DSM configuration.
+
+- **<a href="https://github.com/007revad/Synology_Plex_Backup">Synology_Plex_Backup</a>**
+  - A script to backup Plex to a tgz file. For DSM 7 and DSM 6.
+
+- **<a href="https://github.com/007revad/Plex_Server_Sync">Plex_Server_Sync</a>**
+  - Sync main Plex server database & metadata to backup Plex server
+
+- **<a href="https://github.com/007revad/ScriptNotify">ScriptNotify</a>**
+  - DSM 7 package to allow your scripts to send DSM notifications

--- a/my-other-scripts.md
+++ b/my-other-scripts.md
@@ -5,6 +5,7 @@
 
 - **<a href="https://github.com/007revad/Synology_enable_M2_volume">Synology_enable_M2_volume</a>**
   - Enable creating volumes with non-Synology M.2 drives.
+  - Enable Health Info for non-Synology NVMe drives.
 
 - **<a href="https://github.com/007revad/Synology_M2_volume">Synology_M2_volume</a>**
   - Easily create an M.2 volume on Synology NAS.

--- a/syno_raidf1_shr_switch.sh
+++ b/syno_raidf1_shr_switch.sh
@@ -215,14 +215,14 @@ if ! printf "%s\n%s\n" "$tag" "$scriptver" |
 
                             # Delete downloaded .tar.gz file
                             if ! rm "/tmp/$script-$shorttag.tar.gz"; then
-                                delerr=1
+                                #delerr=1
                                 echo -e "${Error}ERROR ${Off} Failed to delete"\
                                     "downloaded /tmp/$script-$shorttag.tar.gz!"
                             fi
 
                             # Delete extracted tmp files
                             if ! rm -r "/tmp/$script-$shorttag"; then
-                                delerr=1
+                                #delerr=1
                                 echo -e "${Error}ERROR ${Off} Failed to delete"\
                                     "downloaded /tmp/$script-$shorttag!"
                             fi
@@ -293,11 +293,14 @@ fi
 
 PS3="Select the RAID type: "
 if [[ $enabled == "shr" ]]; then
-    options=("RAID F1" "Restore" "Quit")
+    #options=("RAID F1" "Restore" "Quit")
+    options=("RAID F1" "Quit")
 elif [[ $enabled == "raidf1" ]]; then
-    options=("SHR" "Restore" "Quit")
+    #options=("SHR" "Restore" "Quit")
+    options=("SHR" "Quit")
 else
-    options=("SHR" "RAID F1" "Restore" "Quit")
+    #options=("SHR" "RAID F1" "Restore" "Quit")
+    options=("SHR" "RAID F1" "Quit")
 fi
 select raid in "${options[@]}"; do
     case "$raid" in

--- a/syno_raidf1_shr_switch.sh
+++ b/syno_raidf1_shr_switch.sh
@@ -12,9 +12,15 @@
 # https://kb.synology.com/en-ro/DSM/tutorial/Which_Synology_NAS_models_support_RAID_F1
 #------------------------------------------------------------------------------
 
-scriptver="v1.0.3"
+scriptver="v1.0.4"
 script=Synology_RAID-F1_SHR_switch
 repo="007revad/Synology_RAID-F1_SHR_switch"
+
+# Check BASH variable is is non-empty and posix mode is off, else abort with error.
+[ "$BASH" ] && ! shopt -qo posix || {
+    printf >&2 "This is a bash script, don't run it with sh\n"
+    exit 1
+}
 
 #echo -e "bash version: $(bash --version | head -1 | cut -d' ' -f4)\n"  # debug
 


### PR DESCRIPTION
v1.0.4
- Removed Restore menu choice as it was not needed (and was dangerous to restore synoinfo.conf from a backup in case it was made while using an older DSM version).
- Prevent running with "sh scriptname.sh".